### PR TITLE
Implement basic adaptive Material3 layout

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.material3.window.size.class)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/ee/vampirkoylu/MainActivity.kt
+++ b/app/src/main/java/com/ee/vampirkoylu/MainActivity.kt
@@ -11,13 +11,15 @@ import com.ee.vampirkoylu.ui.navigation.NavGraph
 import com.ee.vampirkoylu.ui.screens.HomeScreen
 import com.ee.vampirkoylu.ui.screens.MainScreenBackground
 import com.ee.vampirkoylu.ui.theme.VampirKoyluTheme
+import com.ee.vampirkoylu.util.rememberWindowWidthSizeClass
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            VampirKoyluTheme {
+            val widthSizeClass = rememberWindowWidthSizeClass()
+            VampirKoyluTheme(widthSizeClass = widthSizeClass) {
                 val navController = rememberNavController()
                 NavGraph.SetupNavGraph(navController = navController)
             }
@@ -28,9 +30,9 @@ class MainActivity : ComponentActivity() {
 @Preview(showBackground = true)
 @Composable
 fun HomeScreenPreview() {
-    VampirKoyluTheme {
+    VampirKoyluTheme(widthSizeClass = androidx.compose.material3.windowsizeclass.WindowWidthSizeClass.Compact) {
         MainScreenBackground {
-            HomeScreen(rememberNavController())
+            HomeScreen(navController = rememberNavController())
         }
     }
 }

--- a/app/src/main/java/com/ee/vampirkoylu/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/ee/vampirkoylu/ui/screens/HomeScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import com.ee.vampirkoylu.ui.theme.LocalWindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.navigation.compose.rememberNavController
 import com.ee.vampirkoylu.R
 import com.ee.vampirkoylu.ui.component.PixelArtButton
@@ -44,21 +46,43 @@ fun MainScreenBackground(content: @Composable () -> Unit) {
 
 @Composable
 fun HomeScreen(navController: NavController) {
+    val widthSizeClass = LocalWindowWidthSizeClass.current
+    if (widthSizeClass == WindowWidthSizeClass.Compact) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(4.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            HomeScreenContent(navController)
+        }
+    } else {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(32.dp),
+            horizontalArrangement = Arrangement.spacedBy(32.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            HomeScreenContent(navController, horizontal = true)
+        }
+    }
+}
+
+@Composable
+private fun HomeScreenContent(navController: NavController, horizontal: Boolean = false) {
+    val containerModifier = if (horizontal) Modifier.weight(1f) else Modifier.fillMaxSize()
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(4.dp),
+        modifier = containerModifier,
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.SpaceBetween
     ) {
         Spacer(modifier = Modifier.height(30.dp))
-        
+
         // Logo ve Başlık
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Row(modifier = Modifier.fillMaxWidth())
-            {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Row(modifier = Modifier.fillMaxWidth()) {
                 Image(
                     painter = painterResource(id = R.drawable.vampir_logo),
                     contentDescription = "Vampir İkonu",

--- a/app/src/main/java/com/ee/vampirkoylu/ui/theme/Theme.kt
+++ b/app/src/main/java/com/ee/vampirkoylu/ui/theme/Theme.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import com.ee.vampirkoylu.ui.theme.LocalWindowWidthSizeClass
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
@@ -38,6 +39,7 @@ fun VampirKoyluTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
+    widthSizeClass: androidx.compose.material3.windowsizeclass.WindowWidthSizeClass = androidx.compose.material3.windowsizeclass.WindowWidthSizeClass.Compact,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {
@@ -50,9 +52,11 @@ fun VampirKoyluTheme(
         else -> LightColorScheme
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
-        content = content
-    )
+    androidx.compose.runtime.CompositionLocalProvider(LocalWindowWidthSizeClass provides widthSizeClass) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = Typography,
+            content = content
+        )
+    }
 }

--- a/app/src/main/java/com/ee/vampirkoylu/ui/theme/WindowSize.kt
+++ b/app/src/main/java/com/ee/vampirkoylu/ui/theme/WindowSize.kt
@@ -1,0 +1,6 @@
+package com.ee.vampirkoylu.ui.theme
+
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.staticCompositionLocalOf
+
+val LocalWindowWidthSizeClass = staticCompositionLocalOf { WindowWidthSizeClass.Compact }

--- a/app/src/main/java/com/ee/vampirkoylu/util/WindowSizeUtils.kt
+++ b/app/src/main/java/com/ee/vampirkoylu/util/WindowSizeUtils.kt
@@ -1,0 +1,13 @@
+package com.ee.vampirkoylu.util
+
+import android.app.Activity
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+fun rememberWindowWidthSizeClass(): WindowWidthSizeClass {
+    val activity = LocalContext.current as Activity
+    return calculateWindowSizeClass(activity).widthSizeClass
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material3-window-size-class = { group = "androidx.compose.material3", name = "material3-window-size-class" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
 
 [plugins]


### PR DESCRIPTION
## Summary
- add Material3 window size class dependency
- provide `LocalWindowWidthSizeClass` via theme
- compute width size class in `MainActivity`
- adapt `HomeScreen` layout based on window width

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6862a498c498832aab1b6f4fe338a117