### PR TITLE
Add premium upgrade dialog with billing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,9 +80,7 @@ dependencies {
     implementation(libs.androidx.material3.window.size.class1)
 
     //Google Play Billing
-
-    //implementation(libs.billing)
-    implementation("com.android.billingclient:billing-ktx:7.0.0")
+    implementation(libs.billing)
     implementation(libs.androidx.datastore.preferences)
 
 

--- a/app/src/main/java/com/ee/vampirkoylu/ui/component/Buttons.kt
+++ b/app/src/main/java/com/ee/vampirkoylu/ui/component/Buttons.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.sp
 import com.ee.vampirkoylu.R
 import com.ee.vampirkoylu.ui.theme.PixelFont
@@ -71,13 +72,15 @@ fun PixelArtButton(
     modifier: Modifier = Modifier,
     fontSize: TextUnit = 24.sp,
     imageId: Int = R.drawable.button_brown, // arka plan görseli
-    color: Color = Color(0xFFF0E68C)
+    color: Color = Color(0xFFF0E68C),
+    width: Dp = 260.dp,
+    height: Dp = 80.dp
 ) {
     Button(
         onClick = onClick,
         modifier = modifier
-            .width(260.dp)
-            .height(80.dp),
+            .width(width)
+            .height(height),
         colors = ButtonDefaults.buttonColors(
             containerColor = Color.Transparent,
             contentColor = color

--- a/app/src/main/java/com/ee/vampirkoylu/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/ee/vampirkoylu/ui/navigation/NavGraph.kt
@@ -22,6 +22,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.ee.vampirkoylu.R
 import com.ee.vampirkoylu.model.GamePhase
+import com.ee.vampirkoylu.BillingClientWrapper
+import com.ee.vampirkoylu.StoreManager
 import com.ee.vampirkoylu.ui.component.PixelArtButton
 import com.ee.vampirkoylu.ui.screens.GameSetupScreen
 import com.ee.vampirkoylu.ui.screens.HomeScreen
@@ -41,12 +43,16 @@ import com.ee.vampirkoylu.ui.theme.DarkBlue
 import com.ee.vampirkoylu.ui.theme.PixelFont
 import com.ee.vampirkoylu.ui.theme.shine_gold
 import com.ee.vampirkoylu.viewmodel.GameViewModel
+import android.app.Activity
 
 object NavGraph {
 
     @Composable
     fun SetupNavGraph(
         navController: NavHostController,
+        billingClientWrapper: BillingClientWrapper,
+        storeManager: StoreManager,
+        activity: Activity,
         gameViewModel: GameViewModel = viewModel()
     ) {
         NavHost(
@@ -55,7 +61,12 @@ object NavGraph {
         ) {
             composable(Screen.Home.route) {
                 MainScreenBackground {
-                    HomeScreen(navController = navController)
+                    HomeScreen(
+                        navController = navController,
+                        billingClientWrapper = billingClientWrapper,
+                        storeManager = storeManager,
+                        activity = activity
+                    )
                 }
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,4 +125,11 @@
     <string name="judgement_result_title">YARGILAMA SONUCU</string>
     <string name="judgement_result_guilty">%1$s suçlu bulundu ve asıldı</string>
     <string name="judgement_result_innocent">%1$s masum bulundu, yaşamasına izin verildi</string>
+
+    <!-- Premium Package -->
+    <string name="premium">PREMIUM</string>
+    <string name="premium_title">PLUS PAKETİ</string>
+    <string name="premium_description">Bu pakette Şerif, Gözcü, Seri Katil ve Doktor rolleri mevcuttur.</string>
+    <string name="upgrade">YÜKSELT</string>
+    <string name="not_now">DAHA SONRA</string>
 </resources>


### PR DESCRIPTION
## Summary
- make `PixelArtButton` size configurable
- add premium strings
- update billing dependency to 8.0.0
- add premium button & dialog on home screen
- pass billing objects through navigation

## Testing
- `gradle test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6867ccb7042c832981fd3b25ea3f2369