### PR TITLE
Add game mode presets

### DIFF
--- a/app/src/main/java/com/ee/vampirkoylu/model/GameMode.kt
+++ b/app/src/main/java/com/ee/vampirkoylu/model/GameMode.kt
@@ -1,0 +1,30 @@
+package com.ee.vampirkoylu.model
+
+enum class GameMode(val nameRes: Int, val settings: GameSettings) {
+    CLASSIC(
+        com.ee.vampirkoylu.R.string.classic_mode,
+        GameSettings(
+            playerCount = 6,
+            vampireCount = 1,
+            sheriffCount = 1,
+            watcherCount = 0,
+            serialKillerCount = 0,
+            doctorCount = 1
+        )
+    ),
+    CHAOS(
+        com.ee.vampirkoylu.R.string.chaos_mode,
+        GameSettings(
+            playerCount = 8,
+            vampireCount = 2,
+            sheriffCount = 1,
+            watcherCount = 1,
+            serialKillerCount = 1,
+            doctorCount = 1
+        )
+    ),
+    CUSTOM(
+        com.ee.vampirkoylu.R.string.custom_mode,
+        GameSettings()
+    );
+}

--- a/app/src/main/java/com/ee/vampirkoylu/ui/component/ModeSelector.kt
+++ b/app/src/main/java/com/ee/vampirkoylu/ui/component/ModeSelector.kt
@@ -1,0 +1,79 @@
+package com.ee.vampirkoylu.ui.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ee.vampirkoylu.R
+import com.ee.vampirkoylu.ui.theme.Gold
+import com.ee.vampirkoylu.ui.theme.PixelFont
+
+@Composable
+fun ModeSelector(
+    modes: List<Int>,
+    selectedIndex: Int,
+    onIndexChange: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+    ) {
+        val canDecrease = selectedIndex > 0
+        IconButton(
+            onClick = { if (canDecrease) onIndexChange(selectedIndex - 1) },
+            modifier = Modifier.size(28.dp)
+        ) {
+            Image(
+                painterResource(R.drawable.text_block),
+                contentScale = ContentScale.FillBounds,
+                modifier = Modifier.wrapContentSize(),
+                contentDescription = "Previous mode",
+            )
+            Text(
+                text = "<",
+                fontSize = 18.sp,
+                color = if (canDecrease) Gold else Gold.copy(alpha = 0.5f)
+            )
+        }
+
+        Text(
+            text = stringResource(id = modes[selectedIndex]),
+            fontSize = 16.sp,
+            fontFamily = PixelFont,
+            color = Gold,
+            modifier = Modifier.padding(horizontal = 8.dp)
+        )
+
+        val canIncrease = selectedIndex < modes.lastIndex
+        IconButton(
+            onClick = { if (canIncrease) onIndexChange(selectedIndex + 1) },
+            modifier = Modifier.size(28.dp)
+        ) {
+            Image(
+                painterResource(R.drawable.text_block),
+                contentScale = ContentScale.FillBounds,
+                modifier = Modifier.wrapContentSize(),
+                contentDescription = "Next mode",
+            )
+            Text(
+                text = ">",
+                fontSize = 18.sp,
+                color = if (canIncrease) Gold else Gold.copy(alpha = 0.5f)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/ee/vampirkoylu/ui/component/RoleCountSelector.kt
+++ b/app/src/main/java/com/ee/vampirkoylu/ui/component/RoleCountSelector.kt
@@ -19,7 +19,8 @@ fun RoleCountSelector(
     count: Int,
     maxCount: Int,
     onIncrease: () -> Unit,
-    onDecrease: () -> Unit
+    onDecrease: () -> Unit,
+    editable: Boolean = true
 ) {
     Row(
         modifier = Modifier
@@ -40,8 +41,8 @@ fun RoleCountSelector(
             count = count,
             onIncrease = onIncrease,
             onDecrease = onDecrease,
-            canIncrease = count < maxCount,
-            canDecrease = count > 0,
+            canIncrease = editable && count < maxCount,
+            canDecrease = editable && count > 0,
             modifier = Modifier.padding(start = 12.dp)
         )
     }

--- a/app/src/main/java/com/ee/vampirkoylu/ui/screens/GameSetupScreen.kt
+++ b/app/src/main/java/com/ee/vampirkoylu/ui/screens/GameSetupScreen.kt
@@ -43,6 +43,8 @@ import com.ee.vampirkoylu.ui.component.PixelArtButton
 import com.ee.vampirkoylu.ui.component.RoleCountSelector
 import com.ee.vampirkoylu.ui.component.VerticalScrollbar
 import com.ee.vampirkoylu.ui.component.WarningBanner
+import com.ee.vampirkoylu.ui.component.ModeSelector
+import com.ee.vampirkoylu.model.GameMode
 import com.ee.vampirkoylu.ui.navigation.Screen
 import com.ee.vampirkoylu.ui.theme.Beige
 import com.ee.vampirkoylu.ui.theme.Gold
@@ -61,6 +63,9 @@ fun GameSetupScreen(
     viewModel: GameViewModel = viewModel()
 ) {
     // State'leri viewModel değerlerine göre başlat
+    val gameModes = remember { GameMode.values().toList() }
+    var selectedMode by remember { mutableStateOf(GameMode.CUSTOM) }
+
     var playerCount by remember { mutableStateOf(settings.playerCount) }
     var vampireCount by remember { mutableStateOf(settings.vampireCount) }
     var sheriffCount by remember { mutableStateOf(settings.sheriffCount) }
@@ -72,6 +77,41 @@ fun GameSetupScreen(
     var veteranCount by remember { mutableStateOf(settings.veteranCount) }
     var madmanCount by remember { mutableStateOf(settings.madmanCount) }
     var wizardCount by remember { mutableStateOf(settings.wizardCount) }
+
+    fun applyMode(mode: GameMode) {
+        selectedMode = mode
+        val s = mode.settings
+        playerCount = s.playerCount
+        vampireCount = s.vampireCount
+        sheriffCount = s.sheriffCount
+        watcherCount = s.watcherCount
+        serialKillerCount = s.serialKillerCount
+        doctorCount = s.doctorCount
+        saboteurCount = s.voteSaboteurCount
+        autopsirCount = s.autopsirCount
+        veteranCount = s.veteranCount
+        madmanCount = s.madmanCount
+        wizardCount = s.wizardCount
+        playerNames.clear()
+        repeat(playerCount) { playerNames.add("") }
+        onSettingsChange(
+            playerCount,
+            vampireCount,
+            sheriffCount,
+            watcherCount,
+            serialKillerCount,
+            doctorCount,
+            saboteurCount,
+            autopsirCount,
+            veteranCount,
+            madmanCount,
+            wizardCount
+        )
+    }
+
+    LaunchedEffect(Unit) {
+        applyMode(selectedMode)
+    }
 
 
     val playerNames = remember {
@@ -146,6 +186,29 @@ fun GameSetupScreen(
                         modifier = Modifier.padding(4.dp),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
+                        // Oyun modu
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                text = stringResource(id = R.string.game_mode),
+                                fontSize = 14.sp,
+                                fontFamily = PixelFont,
+                                color = Beige,
+                                modifier = Modifier.weight(1f)
+                            )
+
+                            ModeSelector(
+                                modes = gameModes.map { it.nameRes },
+                                selectedIndex = gameModes.indexOf(selectedMode),
+                                onIndexChange = { applyMode(gameModes[it]) }
+                            )
+                        }
+
                         // Oyuncu sayısı
                         Row(
                             modifier = Modifier
@@ -209,8 +272,8 @@ fun GameSetupScreen(
                                         playerNames.removeAt(playerNames.lastIndex)
                                     }
                                 },
-                                canIncrease = playerCount < 15,
-                                canDecrease = playerCount > 4,
+                                canIncrease = selectedMode == GameMode.CUSTOM && playerCount < 15,
+                                canDecrease = selectedMode == GameMode.CUSTOM && playerCount > 4,
                                 showWarningOnIncrease = {
                                     warningMessage = "Oyuncu sayısı en fazla 15 olabilir!"
                                     showWarning = true
@@ -225,85 +288,6 @@ fun GameSetupScreen(
 
                         }
 
-                        // Vampir sayısı
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.SpaceBetween
-                        ) {
-                            Text(
-                                text = stringResource(id = R.string.vampire_count),
-                                fontSize = 14.sp,
-                                fontFamily = PixelFont,
-                                color = Beige,
-                                modifier = Modifier.weight(1f)
-                            )
-
-                            IncreaseDecreaseCount(
-                                count = vampireCount,
-                                onIncrease = {
-                                    val newVampireCount = vampireCount + 1
-                                    vampireCount = newVampireCount
-                                    onSettingsChange(
-                                        playerCount,
-                                        vampireCount,
-                                        sheriffCount,
-                                        watcherCount,
-                                        serialKillerCount,
-                                        doctorCount,
-                                        saboteurCount,
-                                        autopsirCount,
-                                        veteranCount,
-                                        madmanCount,
-                                        wizardCount
-                                    )
-
-                                },
-                                onDecrease = {
-                                    val newVampireCount = vampireCount - 1
-                                    vampireCount = newVampireCount
-                                    onSettingsChange(
-                                        playerCount,
-                                        vampireCount,
-                                        sheriffCount,
-                                        watcherCount,
-                                        serialKillerCount,
-                                        doctorCount,
-                                        saboteurCount,
-                                        autopsirCount,
-                                        veteranCount,
-                                        madmanCount,
-                                        wizardCount
-                                    )
-
-                                },
-                                canIncrease = vampireCount < maxVampireCount,
-                                canDecrease = vampireCount > 1,
-                                fontSize = 20.sp,
-                                showWarningOnIncrease = {
-                                    warningMessage =
-                                        "Maksimum vampir sayısına ulaşıldı! (Max: $maxVampireCount)"
-                                    showWarning = true
-                                },
-                                showWarningOnDecrease = {
-                                    warningMessage = "En az 1 vampir olmalıdır!"
-                                    showWarning = true
-                                },
-                                modifier = Modifier.padding(start = 12.dp)
-                            )
-                        }
-
-                        // Vampir sayısı açıklaması
-                        Text(
-                            text = "Max: $maxVampireCount",
-                            fontSize = 14.sp,
-                            fontFamily = PixelFont,
-                            color = Gold.copy(alpha = 0.7f),
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.padding(top = 4.dp, bottom = 4.dp)
-                        )
                     }
                 }
 
@@ -346,6 +330,56 @@ fun GameSetupScreen(
                                     .verticalScroll(roleScrollState),
                                 horizontalAlignment = Alignment.CenterHorizontally,
                             ) {
+                                // Vampir sayısı
+                                RoleCountSelector(
+                                    title = stringResource(id = R.string.vampire_count),
+                                    count = vampireCount,
+                                    maxCount = maxVampireCount,
+                                    onIncrease = {
+                                        val newVampireCount = vampireCount + 1
+                                        vampireCount = newVampireCount
+                                        onSettingsChange(
+                                            playerCount,
+                                            vampireCount,
+                                            sheriffCount,
+                                            watcherCount,
+                                            serialKillerCount,
+                                            doctorCount,
+                                            saboteurCount,
+                                            autopsirCount,
+                                            veteranCount,
+                                            madmanCount,
+                                            wizardCount
+                                        )
+                                    },
+                                    onDecrease = {
+                                        val newVampireCount = vampireCount - 1
+                                        vampireCount = newVampireCount
+                                        onSettingsChange(
+                                            playerCount,
+                                            vampireCount,
+                                            sheriffCount,
+                                            watcherCount,
+                                            serialKillerCount,
+                                            doctorCount,
+                                            saboteurCount,
+                                            autopsirCount,
+                                            veteranCount,
+                                            madmanCount,
+                                            wizardCount
+                                        )
+                                    },
+                                    editable = selectedMode == GameMode.CUSTOM
+                                )
+                                Text(
+                                    text = "Max: $maxVampireCount",
+                                    fontSize = 14.sp,
+                                    fontFamily = PixelFont,
+                                    color = Gold.copy(alpha = 0.7f),
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.padding(top = 4.dp, bottom = 4.dp)
+                                )
+
                                 // Şerif sayısı
                                 RoleCountSelector(
                                     title = stringResource(id = R.string.sheriff_count),
@@ -390,7 +424,8 @@ fun GameSetupScreen(
                                             wizardCount
                                         )
 
-                                    }
+                                    },
+                                    editable = selectedMode == GameMode.CUSTOM
                                 )
 
                                 // Gözcü sayısı
@@ -437,7 +472,8 @@ fun GameSetupScreen(
                                             wizardCount
                                         )
 
-                                    }
+                                    },
+                                    editable = selectedMode == GameMode.CUSTOM
                                 )
 
                                 // Seri Katil sayısı
@@ -484,7 +520,8 @@ fun GameSetupScreen(
                                             wizardCount
                                         )
 
-                                    }
+                                    },
+                                    editable = selectedMode == GameMode.CUSTOM
                                 )
 
                                 // Doktor sayısı
@@ -531,14 +568,15 @@ fun GameSetupScreen(
                                             wizardCount
                                         )
 
-                                    }
+                                    },
+                                    editable = selectedMode == GameMode.CUSTOM
                                 )
 
                                 if (!isPlusUser) {
-                                    RoleCountSelector(
-                                        title = stringResource(id = R.string.vote_saboteur_count),
-                                        count = saboteurCount,
-                                        maxCount = 1,
+                                RoleCountSelector(
+                                    title = stringResource(id = R.string.vote_saboteur_count),
+                                    count = saboteurCount,
+                                    maxCount = 1,
                                         onIncrease = {
                                             if (specialRoleCount < maxRoleCount) {
                                                 saboteurCount = 1
@@ -576,7 +614,8 @@ fun GameSetupScreen(
                                                 madmanCount,
                                                 wizardCount
                                             )
-                                        }
+                                        },
+                                        editable = selectedMode == GameMode.CUSTOM
                                     )
 
                                     RoleCountSelector(
@@ -620,7 +659,8 @@ fun GameSetupScreen(
                                                 madmanCount,
                                                 wizardCount
                                             )
-                                        }
+                                        },
+                                        editable = selectedMode == GameMode.CUSTOM
                                     )
 
                                     RoleCountSelector(
@@ -664,7 +704,8 @@ fun GameSetupScreen(
                                                 madmanCount,
                                                 wizardCount
                                             )
-                                        }
+                                        },
+                                        editable = selectedMode == GameMode.CUSTOM
                                     )
 
                                     RoleCountSelector(
@@ -708,7 +749,8 @@ fun GameSetupScreen(
                                                 madmanCount,
                                                 wizardCount
                                             )
-                                        }
+                                        },
+                                        editable = selectedMode == GameMode.CUSTOM
                                     )
 
                                     RoleCountSelector(
@@ -752,7 +794,8 @@ fun GameSetupScreen(
                                                 madmanCount,
                                                 wizardCount
                                             )
-                                        }
+                                        },
+                                        editable = selectedMode == GameMode.CUSTOM
                                     )
                                 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,10 @@
     <string name="new_game">YENİ OYUN</string>
     <string name="enter_names">İSİMLERİ GİRİN</string>
     <string name="player_count">OYNAYAN OYUNCU</string>
+    <string name="game_mode">OYUN MODU</string>
+    <string name="classic_mode">KLASİK</string>
+    <string name="chaos_mode">KAOS</string>
+    <string name="custom_mode">ÖZEL</string>
     <string name="vampire_count">VAMPİR</string>
     <string name="start">BAŞLAT</string>
     


### PR DESCRIPTION
## Summary
- add `GameMode` enum with preset counts
- allow selecting preset via new `ModeSelector` component
- move vampire count under role settings and disable editing unless in Custom mode
- add strings for game mode selection
- make `RoleCountSelector` support disabled state

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6869572daa1083298be98d940da5a2da