### PR TITLE
Improve custom game setup validation

### DIFF
--- a/app/src/main/java/com/ee/vampirkoylu/ui/component/RoleCountSelector.kt
+++ b/app/src/main/java/com/ee/vampirkoylu/ui/component/RoleCountSelector.kt
@@ -20,7 +20,9 @@ fun RoleCountSelector(
     maxCount: Int,
     onIncrease: () -> Unit,
     onDecrease: () -> Unit,
-    editable: Boolean = true
+    editable: Boolean = true,
+    showWarningOnIncrease: (() -> Unit)? = null,
+    showWarningOnDecrease: (() -> Unit)? = null
 ) {
     Row(
         modifier = Modifier
@@ -43,6 +45,8 @@ fun RoleCountSelector(
             onDecrease = onDecrease,
             canIncrease = editable && count < maxCount,
             canDecrease = editable && count > 0,
+            showWarningOnIncrease = showWarningOnIncrease,
+            showWarningOnDecrease = showWarningOnDecrease,
             modifier = Modifier.padding(start = 12.dp)
         )
     }

--- a/app/src/main/java/com/ee/vampirkoylu/ui/screens/GameSetupScreen.kt
+++ b/app/src/main/java/com/ee/vampirkoylu/ui/screens/GameSetupScreen.kt
@@ -368,15 +368,11 @@ fun GameSetupScreen(
                                             wizardCount
                                         )
                                     },
-                                    editable = selectedMode == GameMode.CUSTOM
-                                )
-                                Text(
-                                    text = "Max: $maxVampireCount",
-                                    fontSize = 14.sp,
-                                    fontFamily = PixelFont,
-                                    color = Gold.copy(alpha = 0.7f),
-                                    textAlign = TextAlign.Center,
-                                    modifier = Modifier.padding(top = 4.dp, bottom = 4.dp)
+                                    editable = selectedMode == GameMode.CUSTOM,
+                                    showWarningOnIncrease = {
+                                        warningMessage = "Bu rolden en fazla $maxVampireCount tane olabilir!"
+                                        showWarning = true
+                                    }
                                 )
 
                                 // Şerif sayısı
@@ -424,7 +420,11 @@ fun GameSetupScreen(
                                         )
 
                                     },
-                                    editable = selectedMode == GameMode.CUSTOM
+                                    editable = selectedMode == GameMode.CUSTOM,
+                                    showWarningOnIncrease = {
+                                        warningMessage = "Bu rolden en fazla 1 tane olabilir!"
+                                        showWarning = true
+                                    }
                                 )
 
                                 // Gözcü sayısı
@@ -472,7 +472,11 @@ fun GameSetupScreen(
                                         )
 
                                     },
-                                    editable = selectedMode == GameMode.CUSTOM
+                                    editable = selectedMode == GameMode.CUSTOM,
+                                    showWarningOnIncrease = {
+                                        warningMessage = "Bu rolden en fazla 1 tane olabilir!"
+                                        showWarning = true
+                                    }
                                 )
 
                                 // Seri Katil sayısı
@@ -520,7 +524,11 @@ fun GameSetupScreen(
                                         )
 
                                     },
-                                    editable = selectedMode == GameMode.CUSTOM
+                                    editable = selectedMode == GameMode.CUSTOM,
+                                    showWarningOnIncrease = {
+                                        warningMessage = "Bu rolden en fazla 1 tane olabilir!"
+                                        showWarning = true
+                                    }
                                 )
 
                                 // Doktor sayısı
@@ -568,7 +576,11 @@ fun GameSetupScreen(
                                         )
 
                                     },
-                                    editable = selectedMode == GameMode.CUSTOM
+                                    editable = selectedMode == GameMode.CUSTOM,
+                                    showWarningOnIncrease = {
+                                        warningMessage = "Bu rolden en fazla 1 tane olabilir!"
+                                        showWarning = true
+                                    }
                                 )
 
                                 if (!isPlusUser) {
@@ -614,7 +626,11 @@ fun GameSetupScreen(
                                                 wizardCount
                                             )
                                         },
-                                        editable = selectedMode == GameMode.CUSTOM
+                                        editable = selectedMode == GameMode.CUSTOM,
+                                        showWarningOnIncrease = {
+                                            warningMessage = "Bu rolden en fazla 1 tane olabilir!"
+                                            showWarning = true
+                                        }
                                     )
 
                                     RoleCountSelector(
@@ -659,7 +675,11 @@ fun GameSetupScreen(
                                                 wizardCount
                                             )
                                         },
-                                        editable = selectedMode == GameMode.CUSTOM
+                                        editable = selectedMode == GameMode.CUSTOM,
+                                        showWarningOnIncrease = {
+                                            warningMessage = "Bu rolden en fazla 1 tane olabilir!"
+                                            showWarning = true
+                                        }
                                     )
 
                                     RoleCountSelector(
@@ -704,7 +724,11 @@ fun GameSetupScreen(
                                                 wizardCount
                                             )
                                         },
-                                        editable = selectedMode == GameMode.CUSTOM
+                                        editable = selectedMode == GameMode.CUSTOM,
+                                        showWarningOnIncrease = {
+                                            warningMessage = "Bu rolden en fazla 1 tane olabilir!"
+                                            showWarning = true
+                                        }
                                     )
 
                                     RoleCountSelector(
@@ -749,7 +773,11 @@ fun GameSetupScreen(
                                                 wizardCount
                                             )
                                         },
-                                        editable = selectedMode == GameMode.CUSTOM
+                                        editable = selectedMode == GameMode.CUSTOM,
+                                        showWarningOnIncrease = {
+                                            warningMessage = "Bu rolden en fazla 1 tane olabilir!"
+                                            showWarning = true
+                                        }
                                     )
 
                                     RoleCountSelector(
@@ -794,7 +822,11 @@ fun GameSetupScreen(
                                                 wizardCount
                                             )
                                         },
-                                        editable = selectedMode == GameMode.CUSTOM
+                                        editable = selectedMode == GameMode.CUSTOM,
+                                        showWarningOnIncrease = {
+                                            warningMessage = "Bu rolden en fazla 1 tane olabilir!"
+                                            showWarning = true
+                                        }
                                     )
                                 }
 
@@ -869,11 +901,14 @@ fun GameSetupScreen(
                     PixelArtButton(
                         text = stringResource(id = R.string.start),
                         onClick = {
-                            if (allNamesEntered) {
-                                onStartGame(playerNames.toList())
-                            } else {
+                            if (!allNamesEntered) {
                                 warningMessage = "Tüm oyuncuların isimlerini girmelisiniz!"
                                 showWarning = true
+                            } else if (selectedMode == GameMode.CUSTOM && vampireCount == 0 && serialKillerCount == 0) {
+                                warningMessage = "En az 1 tane vampir veya seri katil rolü bulunmalı!"
+                                showWarning = true
+                            } else {
+                                onStartGame(playerNames.toList())
                             }
                         },
                         color = Beige,


### PR DESCRIPTION
## Summary
- warn if trying to modify role counts above the allowed amount
- remove static "Max" label for vampire count
- show an error when starting a custom game without a vampire or serial killer

## Testing
- `./gradlew tasks --all` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_686961803734832986d0723ba1dddf98